### PR TITLE
サインアップ、ログイン周りの修正

### DIFF
--- a/app/assets/stylesheets/login.css
+++ b/app/assets/stylesheets/login.css
@@ -1,0 +1,67 @@
+.sign-up {
+  margin: 7% auto;
+}
+.sign-up-box {
+  width: 35%;
+  margin: auto;
+  text-align: center;
+  border: solid 1px black;
+}
+.sign-up-header {
+  width: 100%;
+  background-color: black;
+  padding: 5% 0%;
+}
+.sign-up-header h2{
+  font-size: 1.5rem;
+  font-weight: 100;
+  margin: 0;
+  color: rgb(201, 185, 185);
+  font-family: system-ui;
+}
+.sign-up-form .field, .actions{
+  padding: 5% 0;
+}
+.sign-up-form .field input {
+  width: 50%;
+  border: none;
+  border-bottom: solid 1px black;
+  color: black;
+  font-size: 1.2rem;
+  font-family: system-ui;
+  font-weight: 100;
+}
+.sign-up-form .field input:focus {
+  outline: none;
+  border-bottom: solid rgb(38, 75, 112) 2px;
+}
+.sign-up-form .field select {
+  text-align: center;
+  margin: 0 3%;
+  border: none;
+  border-bottom: solid rgb(38, 75, 112) 1px;
+  color: black;
+  font-size: 1.3rem;
+  font-family: system-ui;
+  font-weight: 100;
+}
+.sign-up-form .field select:focus {
+  outline: none;
+  border-bottom: solid rgb(38, 75, 112) 2px;
+}
+
+.sign-up-form .actions input {
+  padding: 3% 8%;
+  font-size: 1.2rem;
+  font-family: system-ui;
+  font-weight: 100;
+}
+.link-login {
+  width: 50%;
+  margin: 5% auto 0;
+  text-align: center;
+}
+.link-login a{
+  text-decoration: none;
+}
+

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,12 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  def after_sign_in_path_for(resource)
+    root_path
+  end
+
+  private
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name,  :birth_date])
+  end
 end

--- a/app/controllers/end_users/confirmations_controller.rb
+++ b/app/controllers/end_users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class EndUsers::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/end_users/omniauth_callbacks_controller.rb
+++ b/app/controllers/end_users/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class EndUsers::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/heartcombo/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/end_users/passwords_controller.rb
+++ b/app/controllers/end_users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class EndUsers::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/end_users/registrations_controller.rb
+++ b/app/controllers/end_users/registrations_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class EndUsers::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/end_users/sessions_controller.rb
+++ b/app/controllers/end_users/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class EndUsers::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/end_users/unlocks_controller.rb
+++ b/app/controllers/end_users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class EndUsers::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/models/end_user.rb
+++ b/app/models/end_user.rb
@@ -24,5 +24,7 @@ class EndUser < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  validates :name, presence: true, uniqueness: true
+  validates :email, presence: true
   has_many :ideas
 end

--- a/app/models/end_user.rb
+++ b/app/models/end_user.rb
@@ -6,7 +6,7 @@
 #  birth_date             :date
 #  email                  :string(255)      default(""), not null
 #  encrypted_password     :string(255)      default(""), not null
-#  introduction           :text(65535)      not null
+#  introduction           :text(65535)
 #  name                   :string(255)      not null
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime

--- a/app/views/end_users/confirmations/new.html.erb
+++ b/app/views/end_users/confirmations/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend confirmation instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "end_users/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend confirmation instructions" %>
+  </div>
+<% end %>
+
+<%= render "end_users/shared/links" %>

--- a/app/views/end_users/mailer/confirmation_instructions.html.erb
+++ b/app/views/end_users/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,5 @@
+<p>Welcome <%= @email %>!</p>
+
+<p>You can confirm your account email through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/end_users/mailer/email_changed.html.erb
+++ b/app/views/end_users/mailer/email_changed.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @email %>!</p>
+
+<% if @resource.try(:unconfirmed_email?) %>
+  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+<% else %>
+  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+<% end %>

--- a/app/views/end_users/mailer/password_change.html.erb
+++ b/app/views/end_users/mailer/password_change.html.erb
@@ -1,0 +1,3 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>We're contacting you to notify you that your password has been changed.</p>

--- a/app/views/end_users/mailer/reset_password_instructions.html.erb
+++ b/app/views/end_users/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>If you didn't request this, please ignore this email.</p>
+<p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/end_users/mailer/unlock_instructions.html.erb
+++ b/app/views/end_users/mailer/unlock_instructions.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+
+<p>Click the link below to unlock your account:</p>
+
+<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/end_users/passwords/edit.html.erb
+++ b/app/views/end_users/passwords/edit.html.erb
@@ -1,0 +1,25 @@
+<h2>Change your password</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "end_users/shared/error_messages", resource: resource %>
+  <%= f.hidden_field :reset_password_token %>
+
+  <div class="field">
+    <%= f.label :password, "New password" %><br />
+    <% if @minimum_password_length %>
+      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+    <% end %>
+    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation, "Confirm new password" %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Change my password" %>
+  </div>
+<% end %>
+
+<%= render "end_users/shared/links" %>

--- a/app/views/end_users/passwords/new.html.erb
+++ b/app/views/end_users/passwords/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Forgot your password?</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "end_users/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Send me reset password instructions" %>
+  </div>
+<% end %>
+
+<%= render "end_users/shared/links" %>

--- a/app/views/end_users/registrations/edit.html.erb
+++ b/app/views/end_users/registrations/edit.html.erb
@@ -1,0 +1,43 @@
+<h2>Edit <%= resource_name.to_s.humanize %></h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "end_users/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.password_field :password, autocomplete: "new-password" %>
+    <% if @minimum_password_length %>
+      <br />
+      <em><%= @minimum_password_length %> characters minimum</em>
+    <% end %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.password_field :current_password, autocomplete: "current-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Update" %>
+  </div>
+<% end %>
+
+<h3>Cancel my account</h3>
+
+<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+
+<%= link_to "Back", :back %>

--- a/app/views/end_users/registrations/new.html.erb
+++ b/app/views/end_users/registrations/new.html.erb
@@ -1,0 +1,36 @@
+<% content_for :css do %>
+  <%= stylesheet_pack_tag 'login', media: "all" %>
+<% end %>
+<div class="sign-up">
+  <div class="sign-up-box">
+    <div class="sign-up-header">
+      <h2>Sign up</h2>
+    </div>
+    <div class="sign-up-form">
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+        <%= render "end_users/shared/error_messages", resource: resource %>
+        <div class="field">
+          <%= f.text_field :name , autofocus: true, autocomplete: "name", placeholder:"name" %>
+        </div>
+        <div class="field">
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder:"email" %>
+        </div>
+        <div class="field">
+          <%= f.date_select :birth_date, use_month_numbers: true, start_year: 1950, end_year: Time.now.year ,default: Date.new(2000, 1, 1), autofocus: true, autocomplete: "birth_date" %>
+        </div>
+        <div class="field">
+          <%= f.password_field :password, autocomplete: "new-password", placeholder:"password" %>
+        </div>
+        <div class="field">
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder:"password_confirmation" %>
+        </div>
+        <div class="actions">
+          <%= f.submit "Sign up" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+  <div class="link-login">
+      <%= link_to "登録済みの方はこちら", end_user_session_path %>
+    </div>
+</div>

--- a/app/views/end_users/sessions/new.html.erb
+++ b/app/views/end_users/sessions/new.html.erb
@@ -1,0 +1,30 @@
+<% content_for :css do %>
+  <%= stylesheet_pack_tag 'login', media: "all" %>
+<% end %>
+<div class="sign-up">
+  <div class="sign-up-box">
+    <div class="sign-up-header">
+      <h2>Log in</h2>
+    </div>
+    <div class="sign-up-form">
+      <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>        <%= render "end_users/shared/error_messages", resource: resource %>
+        <div class="field">
+          <%= f.text_field :name , autofocus: true, autocomplete: "name", placeholder:"name" %>
+        </div>
+        <div class="field">
+          <%= f.password_field :password, autocomplete: "new-password", placeholder:"password" %>
+        </div>
+        <div class="field">
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder:"password_confirmation" %>
+        </div>
+        <div class="actions">
+          <%= f.submit "Log in" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+  <div class="link-login">
+      <%= link_to "新規登録の方はこちら", new_end_user_registration_path %>
+  </div>
+</div>
+

--- a/app/views/end_users/shared/_error_messages.html.erb
+++ b/app/views/end_users/shared/_error_messages.html.erb
@@ -1,0 +1,15 @@
+<% if resource.errors.any? %>
+  <div id="error_explanation">
+    <h2>
+      <%= I18n.t("errors.messages.not_saved",
+                 count: resource.errors.count,
+                 resource: resource.class.model_name.human.downcase)
+       %>
+    </h2>
+    <ul>
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/end_users/shared/_links.html.erb
+++ b/app/views/end_users/shared/_links.html.erb
@@ -1,0 +1,25 @@
+<%- if controller_name != 'sessions' %>
+  <%= link_to "Log in", new_session_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post %><br />
+  <% end %>
+<% end %>

--- a/app/views/end_users/unlocks/new.html.erb
+++ b/app/views/end_users/unlocks/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend unlock instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "end_users/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend unlock instructions" %>
+  </div>
+<% end %>
+
+<%= render "end_users/shared/links" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,8 +19,8 @@
           <!-- *_path はUserモデルを作成したときに、
           deviseにより自動で作成されてますので、rake routesで確認できます -->
           Logged in as <strong><%= current_end_user.email %></strong>.
-          <%= link_to 'プロフィール変更', edit_user_registration_path %> |
-          <%= link_to "ログアウト", sign_out_path %>
+          <%= link_to 'プロフィール変更', edit_end_user_registration_path %> |
+          <%= link_to "ログアウト", destroy_end_user_session_path %>
         <% else %>
           <%= link_to "サインイン", new_end_user_registration_path %> |
           <%= link_to "ログイン", new_end_user_session_path %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -46,7 +46,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:email]
+  config.authentication_keys = [:name]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
-  devise_for :end_users
+  devise_for :end_users, controllers: {
+    sessions:      'end_users/sessions',
+    passwords:     'end_users/passwords',
+    registrations: 'end_users/registrations'
+  }
   get 'home/index'
   get 'home/show'
   root to: 'ideas#index'

--- a/db/migrate/20211209163959_devise_create_end_users.rb
+++ b/db/migrate/20211209163959_devise_create_end_users.rb
@@ -34,7 +34,7 @@ class DeviseCreateEndUsers < ActiveRecord::Migration[6.1]
 
       t.string :name, null: false
       t.text :introduction
-      t.date :birth_date,　null: false
+      t.date :birth_date
 
       t.timestamps null: false
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,7 +19,7 @@ ActiveRecord::Schema.define(version: 2021_12_10_154816) do
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.string "name", null: false
-    t.text "introduction", null: false
+    t.text "introduction"
     t.date "birth_date"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/test/fixtures/end_users.yml
+++ b/test/fixtures/end_users.yml
@@ -6,7 +6,7 @@
 #  birth_date             :date
 #  email                  :string(255)      default(""), not null
 #  encrypted_password     :string(255)      default(""), not null
-#  introduction           :text(65535)      not null
+#  introduction           :text(65535)
 #  name                   :string(255)      not null
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime

--- a/test/models/end_user_test.rb
+++ b/test/models/end_user_test.rb
@@ -6,7 +6,7 @@
 #  birth_date             :date
 #  email                  :string(255)      default(""), not null
 #  encrypted_password     :string(255)      default(""), not null
-#  introduction           :text(65535)      not null
+#  introduction           :text(65535)
 #  name                   :string(255)      not null
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime


### PR DESCRIPTION
fix #6 

## やったこと
- サインアップのデザインを整えた。
- ログインのデザインを整えた
- サインアップに誕生日追加
- ログインを名前でできる様にした。
- ログイン後のルート指定
- バリデーションの追加
- カラムの修正

## 画像
- ログイン
<img width="1439" alt="スクリーンショット 2022-01-05 17 05 03" src="https://user-images.githubusercontent.com/68760801/148182689-75c98c3d-1f42-4e8e-8b00-491a4a4c3e5a.png">

- サインアップ
<img width="1439" alt="スクリーンショット 2022-01-05 17 04 52" src="https://user-images.githubusercontent.com/68760801/148182722-7d09c8d3-f34e-4938-a45b-e9809f3426f9.png">
